### PR TITLE
wbank: fix accounts to be returned as empty slice

### DIFF
--- a/bank/persistence/mongo.go
+++ b/bank/persistence/mongo.go
@@ -83,7 +83,7 @@ func (se *mongoSessionStore) GetAccounts(userID string) ([]*domain.Account, erro
 	session := se.Session.Clone()
 	defer session.Close()
 
-	var result []*domain.Account
+	result := make([]*domain.Account, 0)
 
 	err := session.DB(se.DBName).C("accounts").Find(bson.M{"userid": userID}).All(&result)
 	if err != nil {

--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 
 cd frontend
 npm run build
-cp -fr build ../cmd/bankapp/static
+cp build/* ../cmd/bankapp/static -rf


### PR DESCRIPTION
Accounts are not returned as empty [] when there are no such in the persistence.

As additional change build.sh was improve to copy the content instead
of the whole build folder as it makes path to missmatch.