### PR TITLE
bank/backend: get account details

### DIFF
--- a/bank/api/transaction_handlers.go
+++ b/bank/api/transaction_handlers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
 	"github.com/iliyanmotovski/bankv1/bank/domain"
 )
 
@@ -15,6 +16,23 @@ func GetUserAccounts(accountStore domain.AccountStore) http.Handler {
 		result, err := accountStore.GetAccounts(session.UserID)
 		if err != nil {
 			errorResponse(w, http.StatusInternalServerError, "Fetch User Accounts Failed", "error", "unexpected_error", err.Error())
+			return
+		}
+
+		json.NewEncoder(w).Encode(result)
+	})
+}
+
+func GetAccountDetails(accountStore domain.AccountStore) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		session := context.Get(r, "session").(*domain.Session)
+		vars := mux.Vars(r)
+		accountID := vars["accountID"]
+
+		result, err := accountStore.GetAccountDetails(session.UserID, accountID)
+		//TODO(mgenov): distinguish error "not found" from persistence error
+		if err != nil {
+			errorResponse(w, http.StatusNotFound, "Fetch Account Details Failed", "error", "unexpected_error", err.Error())
 			return
 		}
 

--- a/bank/domain/types.go
+++ b/bank/domain/types.go
@@ -60,6 +60,9 @@ type AccountStore interface {
 	// match the UserID. Returns an error if any.
 	GetAccounts(userID string) ([]*Account, error)
 
+	// GetAccountDetails gets the details of the account.
+	GetAccountDetails(userID string, accountID string) (*Account, error)
+
 	// Deposit takes an Account and deposits the incoming money amount from the request to the corresponding
 	// Account in the persistence. Contains the deposit logic. It also inserts history in the persistence that
 	// states a deposit was made, the deposited sum, the time, the UserID and AccountID.

--- a/bank/domain/types_mock.go
+++ b/bank/domain/types_mock.go
@@ -157,6 +157,17 @@ func (_mr *_MockAccountStoreRecorder) GetAccounts(arg0 interface{}) *gomock.Call
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccounts", arg0)
 }
 
+func (_m *MockAccountStore) GetAccountDetails(userID string, accountID string) (*Account, error) {
+	ret := _m.ctrl.Call(_m, "GetAccountDetails", userID, accountID)
+	ret0, _ := ret[0].(*Account)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+func (_mr *_MockAccountStoreRecorder) GetAccountDetails(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetAccountDetails", arg0, arg1)
+}
+
 func (_m *MockAccountStore) Deposit(account Account) (*Account, error) {
 	ret := _m.ctrl.Call(_m, "Deposit", account)
 	ret0, _ := ret[0].(*Account)

--- a/bank/persistence/mongo.go
+++ b/bank/persistence/mongo.go
@@ -93,6 +93,22 @@ func (se *mongoSessionStore) GetAccounts(userID string) ([]*domain.Account, erro
 	return result, nil
 }
 
+func (se *mongoSessionStore) GetAccountDetails(userID string, accountID string) (*domain.Account, error) {
+
+	session := se.Session.Clone()
+	defer session.Close()
+
+	account := new(domain.Account)
+
+	err := session.DB(se.DBName).C("accounts").Find(bson.M{"userid": userID, "accountid": accountID}).One(&account)
+	if err != nil {
+		return nil, err
+	}
+
+	return account, nil
+
+}
+
 func (se *mongoSessionStore) InsertAccount(UserID string, a domain.Account) (string, error) {
 	session := se.Session.Clone()
 	defer session.Close()

--- a/cmd/bankapp/main.go
+++ b/cmd/bankapp/main.go
@@ -48,6 +48,7 @@ func main() {
 	s.Handle("/login", SignUpHandlers.Then(api.LoginHandler(userStore, sessionStore, userSessionDuration))).Methods("POST")
 	s.Handle("/logout", SignUpHandlers.Then(api.LogoutHandler(sessionStore))).Methods("POST")
 	s.Handle("/me/new-account", SecurityHandlers.Then(api.NewUserAccount(accountStore))).Methods("POST")
+	s.Handle("/me/accounts/{accountID}", SecurityHandlers.Then(api.GetAccountDetails(accountStore))).Methods("GET")
 	s.Handle("/me/accounts", SecurityHandlers.Then(api.GetUserAccounts(accountStore))).Methods("GET")
 	s.Handle("/me/delete-account", SecurityHandlers.Then(api.DeleteUserAccount(accountStore))).Methods("DELETE")
 	s.Handle("/me/deposit", SecurityHandlers.Then(api.UserAccountDeposit(accountStore))).Methods("POST")

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -148,3 +148,18 @@ Response:
 - else if logged in and authorized, but requests another users's Account History: 401 Unauthorized + JSON ErrorResponse {"Message":"Fetch User Account History Failed", "Resource":"account", "Field":"account_authorization", "Code":"unauthorized_to_see_this_account_history"}
 
 - else if unexpected server error: 500 Internal Server Error + JSON ErrorResponse {"Message":"Fetch User Account History Failed", "Resource":"error", "Field":"unexpected_error", "Code": THE ERROR BODY}
+
+-------------------------------------------------------------------------------------------------------------------------------
+HISTORY:
+
+/v1/users/me/accounts/:accountID - GET
+
+Expect:
+- User to be logged in
+
+Response:
+- if authorized and successful: 200 OK + JSON Session + JSON Account {"AccountID" string, "UserID" string, "Currency" string, "Amount" string, "Type" string}
+
+- else if unauthorized: 401 Unauthorized + JSON ErrorResponse {"Message":"Authorization Failed", "Resource":"account", "Field":"account_authorization", "Code":"unauthorized"}
+
+- else if logged in and authorized, but requests another users's Account Details: 404 Unauthorized + JSON ErrorResponse {"Message":"Fetch Account Details Failed", "Resource":"account", "Field":"error", "Code":"fetch_account_details_error"}


### PR DESCRIPTION
Added services for retrieving of account details by providing the ID of
the account.

Endpoint:
/v1/users/me/accounts/:accountID

In cases when the requested account is unknown then the backend will
return error as not found.

Doc API is added regarding the change in services.